### PR TITLE
Add LocalStack emulator and CloudWatch metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# Serverless
+# Serverless Photo Processor (Docker Example)
+
+This repository demonstrates a minimal photo-processing pipeline that can be
+run locally on a GPU-enabled machine using Docker. The architecture mirrors the
+AWS serverless design with the following local components:
+
+- **LocalStack** – runs a local instance of core AWS services (S3, IAM,
+  CloudWatch, ECS, EC2, etc.) so you can explore IAM policies, VPCs, and
+  track usage metrics without touching a real AWS account.
+- **Processor** – a PyTorch-based container that watches the upload bucket,
+  performs a simple GPU operation (color inversion), and writes results to the
+  processed bucket while reporting metrics to CloudWatch.
+
+The setup can be used for local development and later ported to actual AWS
+services such as Amazon S3 and SageMaker Studio.
+
+## Prerequisites
+
+- Docker with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- A GPU-capable machine
+
+## Run Locally
+
+```bash
+docker compose up --build
+```
+
+LocalStack exposes AWS APIs on `http://localhost:4566`. Example commands using
+the AWS CLI:
+
+```bash
+aws --endpoint-url=http://localhost:4566 s3 ls
+aws --endpoint-url=http://localhost:4566 iam list-users
+aws --endpoint-url=http://localhost:4566 cloudwatch list-metrics
+aws --endpoint-url=http://localhost:4566 ecs list-clusters
+aws --endpoint-url=http://localhost:4566 ec2 describe-vpcs
+```
+
+Upload images to the `uploads` bucket and watch as processed images appear in
+the `processed` bucket. Each processed image emits a `PhotoPipeline/ImagesProcessed`
+metric to CloudWatch, allowing usage tracking.
+
+## Porting to AWS
+
+The local components correspond to AWS services:
+
+| Local Component | AWS Equivalent |
+| ----------------|---------------|
+| LocalStack S3 buckets `uploads` and `processed` | Amazon S3 buckets |
+| Processor container | AWS Lambda invoking SageMaker |
+
+### Running in SageMaker Studio
+
+1. Build and push the processor image to Amazon ECR.
+2. In SageMaker Studio, create a processing job or Studio image using that
+   container.
+3. The container uses standard IAM credentials, so CloudWatch logs, IAM role
+   permissions, ECS tasks, and VPC configuration can be inspected in the AWS
+   console while jobs run.
+
+The same `AWS_ENDPOINT_URL` environment variable can be omitted in Studio so
+the container talks to real AWS services.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  localstack:
+    image: localstack/localstack:1.4.0
+    environment:
+      SERVICES: s3,iam,cloudwatch,logs,ecs,ec2
+      AWS_DEFAULT_REGION: us-east-1
+    ports:
+      - "4566:4566"
+    volumes:
+      - ./.localstack:/var/lib/localstack
+
+  processor:
+    build: ./processor
+    environment:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_ENDPOINT_URL: http://localstack:4566
+      UPLOAD_BUCKET: uploads
+      OUTPUT_BUCKET: processed
+    depends_on:
+      - localstack
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -1,0 +1,8 @@
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py ./
+CMD ["python", "app.py"]

--- a/processor/app.py
+++ b/processor/app.py
@@ -1,0 +1,84 @@
+import io
+import os
+import time
+
+import boto3
+import numpy as np
+import torch
+from PIL import Image
+
+# Environment variables
+AWS_ENDPOINT_URL = os.environ.get("AWS_ENDPOINT_URL")
+AWS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID")
+AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
+UPLOAD_BUCKET = os.environ.get("UPLOAD_BUCKET", "uploads")
+OUTPUT_BUCKET = os.environ.get("OUTPUT_BUCKET", "processed")
+
+# Configure boto3 for either LocalStack or real AWS
+common_kwargs = {"region_name": AWS_REGION}
+if AWS_ENDPOINT_URL:
+    common_kwargs["endpoint_url"] = AWS_ENDPOINT_URL
+if AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
+    common_kwargs.update(
+        {
+            "aws_access_key_id": AWS_ACCESS_KEY_ID,
+            "aws_secret_access_key": AWS_SECRET_ACCESS_KEY,
+        }
+    )
+s3 = boto3.client("s3", **common_kwargs)
+cloudwatch = boto3.client("cloudwatch", **common_kwargs)
+
+
+def ensure_buckets():
+    """Create buckets if they do not exist."""
+    for bucket in [UPLOAD_BUCKET, OUTPUT_BUCKET]:
+        try:
+            s3.head_bucket(Bucket=bucket)
+        except Exception:
+            s3.create_bucket(Bucket=bucket)
+
+
+def process_image(key: str) -> None:
+    """Download an image, invert colors on GPU, and upload result."""
+    obj = s3.get_object(Bucket=UPLOAD_BUCKET, Key=key)
+    img = Image.open(obj["Body"]).convert("RGB")
+    arr = np.array(img)
+    tensor = torch.tensor(arr, device="cuda")
+    inverted = 255 - tensor
+    result = Image.fromarray(inverted.to("cpu").numpy().astype("uint8"))
+
+    buf = io.BytesIO()
+    result.save(buf, format="JPEG")
+    buf.seek(0)
+    s3.put_object(
+        Bucket=OUTPUT_BUCKET,
+        Key=key,
+        Body=buf,
+        ContentType="image/jpeg",
+    )
+
+    cloudwatch.put_metric_data(
+        Namespace="PhotoPipeline",
+        MetricData=[{"MetricName": "ImagesProcessed", "Value": 1, "Unit": "Count"}],
+    )
+
+
+def main():
+    ensure_buckets()
+    seen = set()
+    while True:
+        resp = s3.list_objects_v2(Bucket=UPLOAD_BUCKET)
+        for obj in resp.get("Contents", []):
+            key = obj["Key"]
+            if key not in seen:
+                print(f"Processing {key}")
+                process_image(key)
+                seen.add(key)
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA GPU not available")
+    main()

--- a/processor/requirements.txt
+++ b/processor/requirements.txt
@@ -1,0 +1,3 @@
+boto3
+Pillow
+numpy


### PR DESCRIPTION
## Summary
- replace MinIO with LocalStack to emulate AWS services including IAM, CloudWatch, ECS, and VPC
- report processed image count to CloudWatch and allow optional connection to real AWS via SageMaker Studio
- document LocalStack usage and SageMaker Studio deployment steps

## Testing
- `python -m py_compile processor/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c630476254832ebb78638b5fc80382